### PR TITLE
etcd-env.sh: use hostname -I instead of hostname -i

### DIFF
--- a/etcd-env.sh
+++ b/etcd-env.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-ipaddress=$(hostname -i)
+ipaddress=$(hostname -I | cut -f1 -d' ')
 export ETCD_NAME=$HOSTNAME
 export ETCD_DATA_DIR=/var/lib/etcd/$HOSTNAME.etcd
 export ETCD_ADVERTISE_CLIENT_URLS=http://${ipaddress}:2379,http://${ipaddress}:4001


### PR DESCRIPTION
It is the recommended way to get an IP address, hostname -i depends on
the configuration of the resolver.

Signed-off-by: Giuseppe Scrivano gscrivan@redhat.com
