### PR TITLE
Dockerfile: add configuration for etcd as system container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,7 @@ ADD uninstall.sh /usr/bin/uninstall.sh
 
 EXPOSE 4001 7001 2379 2380
 
+ADD service.template /exports/service.template
+ADD config.json.template /exports/config.json.template
+
 CMD ["/usr/bin/etcd-env.sh", "/usr/bin/etcd"]

--- a/config.json.template
+++ b/config.json.template
@@ -1,0 +1,154 @@
+{
+	"ociVersion": "0.3.0",
+	"platform": {
+		"os": "linux",
+		"arch": "amd64"
+	},
+	"process": {
+		"terminal": false,
+		"user": {
+			"uid": 0,
+			"gid": 0
+		},
+		"args": [
+			"/usr/bin/etcd-env.sh",
+			"/usr/bin/etcd"
+		],
+		"env": [
+			"NAME=$NAME",
+			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+			"TERM=xterm"
+		],
+		"cwd": "/"
+	},
+	"root": {
+		"path": "rootfs",
+		"readonly": true
+	},
+	"mounts": [
+		{
+			"destination": "/proc",
+			"type": "proc",
+			"source": "proc"
+		},
+		{
+			"destination": "/dev",
+			"type": "tmpfs",
+			"source": "tmpfs",
+			"options": [
+				"nosuid",
+				"strictatime",
+				"mode=755",
+				"size=65536k"
+			]
+		},
+		{
+			"destination": "/dev/pts",
+			"type": "devpts",
+			"source": "devpts",
+			"options": [
+				"nosuid",
+				"noexec",
+				"newinstance",
+				"ptmxmode=0666",
+				"mode=0620",
+				"gid=5"
+			]
+		},
+		{
+			"destination": "/dev/shm",
+			"type": "tmpfs",
+			"source": "shm",
+			"options": [
+				"nosuid",
+				"noexec",
+				"nodev",
+				"mode=1777",
+				"size=65536k"
+			]
+		},
+		{
+			"destination": "/dev/mqueue",
+			"type": "mqueue",
+			"source": "mqueue",
+			"options": [
+				"nosuid",
+				"noexec",
+				"nodev"
+			]
+		},
+		{
+			"destination": "/sys",
+			"type": "sysfs",
+			"source": "sysfs",
+			"options": [
+				"nosuid",
+				"noexec",
+				"nodev"
+			]
+		},
+		{
+			"destination": "/sys/fs/cgroup",
+			"type": "cgroup",
+			"source": "cgroup",
+			"options": [
+				"nosuid",
+				"noexec",
+				"nodev",
+				"relatime",
+				"ro"
+			]
+		},
+		{
+			"type": "bind",
+			"source": "/var/lib",
+			"destination": "/var/lib",
+			"options": [
+				"rbind",
+				"rw",
+				"mode=755"
+			]
+		}
+	],
+	"hooks": {},
+	"linux": {
+		"capabilities": [
+			"CAP_AUDIT_WRITE",
+			"CAP_KILL",
+			"CAP_NET_BIND_SERVICE"
+		],
+		"rlimits": [
+			{
+				"type": "RLIMIT_NOFILE",
+				"hard": 1024,
+				"soft": 1024
+			}
+		],
+		"resources": {
+			"devices": [
+				{
+					"allow": false,
+					"access": "rwm"
+				}
+			]
+		},
+		"namespaces": [
+			{
+				"type": "pid"
+			},
+			{
+				"type": "ipc"
+			},
+			{
+				"type": "mount"
+			}
+		],
+		"devices": null,
+		"apparmorProfile": "",
+		"selinuxProcessLabel": "",
+		"seccomp": {
+			"defaultAction": "",
+			"architectures": null
+		}
+	}
+}

--- a/etcd-env.sh
+++ b/etcd-env.sh
@@ -1,8 +1,11 @@
 #!/bin/sh
 
 ipaddress=$(hostname -I | cut -f1 -d' ')
+if test x$NAME == x; then
+    NAME=$HOSTNAME
+fi
 export ETCD_NAME=$HOSTNAME
-export ETCD_DATA_DIR=/var/lib/etcd/$HOSTNAME.etcd
+export ETCD_DATA_DIR=/var/lib/etcd/${NAME}.etcd
 export ETCD_ADVERTISE_CLIENT_URLS=http://${ipaddress}:2379,http://${ipaddress}:4001
 export ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379,http://0.0.0.0:4001
 export ETCD_INITIAL_ADVERTISE_PEER_URLS=http://${ipaddress}:2380,http://${ipaddress}:7001

--- a/service.template
+++ b/service.template
@@ -1,0 +1,13 @@
+[Unit]
+Description=Etcd Server
+After=network.target
+
+[Service]
+ExecStart=/bin/runc start "$NAME"
+Restart=on-failure
+WorkingDirectory=$DESTDIR
+ExecStop=/bin/runc kill "$NAME"
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
It allows the container to be executed as an Atomic System Container.
The additional files are the configuration for runc and for systemd.

Signed-off-by: Giuseppe Scrivano gscrivan@redhat.com
