### PR TITLE
oci: each container use a different DATA_DIR by default

### DIFF
--- a/config.json.template
+++ b/config.json.template
@@ -15,6 +15,7 @@
 			"/usr/bin/etcd"
 		],
 		"env": [
+                        "ETCD_DATA_DIR=/var/lib/etcd-container/${NAME}.etcd",
 			"NAME=$NAME",
 			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 			"TERM=xterm"

--- a/etcd-env.sh
+++ b/etcd-env.sh
@@ -5,7 +5,7 @@ if test x$NAME == x; then
     NAME=$HOSTNAME
 fi
 export ETCD_NAME=$HOSTNAME
-export ETCD_DATA_DIR=/var/lib/etcd/${NAME}.etcd
+export ETCD_DATA_DIR=${ETCD_DATA_DIR:-/var/lib/etcd/${NAME}.etcd}
 export ETCD_ADVERTISE_CLIENT_URLS=http://${ipaddress}:2379,http://${ipaddress}:4001
 export ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379,http://0.0.0.0:4001
 export ETCD_INITIAL_ADVERTISE_PEER_URLS=http://${ipaddress}:2380,http://${ipaddress}:7001


### PR DESCRIPTION
I am a bit undecided about this change, but it is required at the moment so that /var/lib/etcd can be used without changing its permissions.  We can remove revert in future though, if etcd won't be distributed with the Atomic Host image.

Signed-off-by: Giuseppe Scrivano gscrivan@redhat.com
