### PR TITLE
Service: update to match runc 1.0

### DIFF
--- a/service.template
+++ b/service.template
@@ -3,7 +3,7 @@ Description=Etcd Server
 After=network.target
 
 [Service]
-ExecStart=/bin/runc start "$NAME"
+ExecStart=/bin/runc run "$NAME"
 Restart=on-failure
 WorkingDirectory=$DESTDIR
 ExecStop=/bin/runc kill "$NAME"


### PR DESCRIPTION
"runc start" functionality was ported to "runc run" in runc 1.0
